### PR TITLE
Add expandable tiles UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,48 @@
+.container {
+  padding: 1rem;
+  font-family: sans-serif;
+}
+.controls {
+  margin-bottom: 1rem;
+}
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+}
+.card {
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+}
+.card:hover {
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+.card img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+}
+.card-content {
+  padding: 0.5rem;
+  text-align: center;
+}
+.card-details {
+  background: #f5f5f5;
+  padding: 0.5rem;
+  font-size: 0.9rem;
+}
+.favorite {
+  border-color: #22c55e;
+}
+.btn {
+  margin-top: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border: none;
+  background: #3182ce;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,8 @@
-import methods from "./methods"; //tobacco cessation methods are in methods.js
-import { useState } from 'react';
-// import { Card, CardContent } from "@/components/ui/card";
-// import { Button } from "@/components/ui/button";
+import methods from "./methods"; // tobacco cessation methods are in methods.js
+import { useState } from "react";
 import jsPDF from "jspdf";
 import "jspdf-autotable";
+import "./App.css";
 
 export default function HealBetterTobaccoCessationOptions() {
   const [favorites, setFavorites] = useState([]);
@@ -52,40 +51,36 @@ export default function HealBetterTobaccoCessationOptions() {
   };
 
   return (
-    <div className="p-6">
-      <div className="mb-4">
-        <label className="inline-flex items-center space-x-2">
+    <div className="container">
+      <div className="controls">
+        <label>
           <input
             type="checkbox"
             checked={showFreeSamplesOnly}
             onChange={() => setShowFreeSamplesOnly(!showFreeSamplesOnly)}
-            className="accent-blue-600"
           />
           <span>Show only methods with free samples from MDHHS</span>
         </label>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid">
         {filteredMethods.map((method, index) => (
-          <Card
+          <div
             key={index}
-            className={`relative border-2 transition-all duration-200 ${
-              favorites.includes(method.name) ? 'border-green-500' : 'border-transparent'
-            }`}
+            className={`card ${favorites.includes(method.name) ? 'favorite' : ''}`}
             onClick={() => setExpanded(expanded === method.name ? null : method.name)}
           >
             <img
               src={method.image}
               alt={method.name}
-              className="w-full h-40 object-contain p-4"
             />
-            <CardContent className="text-center">
-              <h2 className="text-lg font-semibold">{method.name}</h2>
-              <p className="text-sm text-gray-600">{method.type}</p>
-            </CardContent>
+            <div className="card-content">
+              <h2>{method.name}</h2>
+              <p>{method.description}</p>
+            </div>
 
             {expanded === method.name && (
-              <div className="bg-gray-100 text-sm p-4">
+              <div className="card-details" onClick={(e) => e.stopPropagation()}>
                 <p><strong>Estimated Cost:</strong> {method.cost}</p>
                 <p><strong>Pros:</strong> {method.pros?.join(", ")}</p>
                 <p><strong>Cons:</strong> {method.cons?.join(", ")}</p>
@@ -93,12 +88,12 @@ export default function HealBetterTobaccoCessationOptions() {
                 <p><strong>How to Get It:</strong> {method.access}</p>
                 <p><strong>Free Sample Available From MDHHS:</strong> {method.sample}</p>
                 <p><strong>GoodRx Estimate:</strong> <a href={method.goodrx} className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">{method.cost} (View on GoodRx)</a></p>
-                <Button className="mt-2" onClick={(e) => { e.stopPropagation(); toggleFavorite(method.name); }}>
-                  {favorites.includes(method.name) ? "Remove from Favorites" : "Add to Favorites"}
-                </Button>
+                <button className="btn" onClick={(e) => { e.stopPropagation(); toggleFavorite(method.name); }}>
+                  {favorites.includes(method.name) ? 'Remove from Favorites' : 'Add to Favorites'}
+                </button>
               </div>
             )}
-          </Card>
+          </div>
         ))}
       </div>
 
@@ -111,9 +106,9 @@ export default function HealBetterTobaccoCessationOptions() {
             <ul className="list-disc pl-5">
               {favorites.map((fav, i) => <li key={i}>{fav}</li>)}
             </ul>
-            <Button className="mt-4" onClick={handleExportPDF}>
-              Export as PDF
-            </Button>
+              <button className="btn" onClick={handleExportPDF}>
+                Export as PDF
+              </button>
           </>
         )}
       </div>

--- a/src/methods.js
+++ b/src/methods.js
@@ -3,6 +3,7 @@ export const methods = [
   {
     name: "Varenicline (Chantix)",
     type: "Prescription Medication",
+    description: "Non-nicotine pill that eases cravings and withdrawal symptoms.",
     cost: "$100–$500/month",
     pros: ["Reduces cravings and withdrawal", "Non-nicotine option"],
     cons: ["Prescription required", "May cause vivid dreams or nausea"],
@@ -10,11 +11,12 @@ export const methods = [
     access: "Ask your primary care provider for a prescription. Covered by most Medicaid and commercial plans in Michigan.",
     sample: "No",
     goodrx: "https://www.goodrx.com/chantix",
-    image: "path/to/varenicline.jpg"
+    image: "https://source.unsplash.com/featured/?pill"
   },
   {
     name: "Bupropion (Zyban)",
     type: "Prescription Medication",
+    description: "Antidepressant that can also reduce tobacco cravings.",
     cost: "$50–$150/month",
     pros: ["Reduces cravings", "May also help with depression"],
     cons: ["Prescription required", "Possible insomnia or dry mouth"],
@@ -22,11 +24,12 @@ export const methods = [
     access: "Talk to your doctor. Often covered under Michigan Medicaid and most commercial plans.",
     sample: "No",
     goodrx: "https://www.goodrx.com/zyban",
-    image: "path/to/bupropion.jpg"
+    image: "https://source.unsplash.com/featured/?medication"
   },
   {
     name: "Nicotine Patch",
     type: "Nicotine Replacement Therapy (NRT)",
+    description: "Provides steady nicotine through the skin all day.",
     cost: "$25–$80/month (OTC)",
     pros: ["Simple to use", "Provides steady nicotine delivery"],
     cons: ["May irritate skin", "Less flexible for cravings"],
@@ -34,11 +37,12 @@ export const methods = [
     access: "Available at Michigan pharmacies. Medicaid and most plans cover with counseling. Free samples may be available through MDHHS.",
     sample: "Yes",
     goodrx: "https://www.goodrx.com/nicotine-patch",
-    image: "path/to/patch.jpg"
+    image: "https://source.unsplash.com/featured/?nicotine-patch"
   },
   {
     name: "Nicotine Gum",
     type: "Nicotine Replacement Therapy (NRT)",
+    description: "Chewable form that helps manage sudden cravings.",
     cost: "$20–$50/month (OTC)",
     pros: ["Helps manage cravings", "Flexible use"],
     cons: ["Chewing technique required", "Mouth or jaw irritation possible"],
@@ -46,11 +50,12 @@ export const methods = [
     access: "Sold OTC in Michigan stores. Medicaid often covers if paired with counseling.",
     sample: "Yes",
     goodrx: "https://www.goodrx.com/nicotine-gum",
-    image: "path/to/gum.jpg"
+    image: "https://source.unsplash.com/featured/?gum"
   },
   {
     name: "Nicotine Lozenge",
     type: "Nicotine Replacement Therapy (NRT)",
+    description: "Dissolves in the mouth to curb oral cravings.",
     cost: "$25–$60/month (OTC)",
     pros: ["Easy to use", "Good for oral cravings"],
     cons: ["May cause mouth or throat irritation"],
@@ -58,11 +63,12 @@ export const methods = [
     access: "Available OTC. Medicaid covers with counseling in Michigan.",
     sample: "Yes",
     goodrx: "https://www.goodrx.com/nicotine-lozenge",
-    image: "path/to/lozenge.jpg"
+    image: "https://source.unsplash.com/featured/?lozenge"
   },
   {
     name: "Nicotine Nasal Spray",
     type: "Nicotine Replacement Therapy (Prescription)",
+    description: "Rapid‑acting spray for intense cravings.",
     cost: "$50–$150/month",
     pros: ["Fast relief", "Helpful for strong cravings"],
     cons: ["Nasal irritation", "Frequent dosing required"],
@@ -70,11 +76,12 @@ export const methods = [
     access: "Prescription required. May be covered by Medicaid or commercial insurance in Michigan.",
     sample: "No",
     goodrx: "https://www.goodrx.com/nicotine-nasal-spray",
-    image: "path/to/spray.jpg"
+    image: "https://source.unsplash.com/featured/?nasal-spray"
   },
   {
     name: "Exercise",
     type: "Behavioral Strategy",
+    description: "Physical activity to distract and improve mood.",
     cost: "Free",
     pros: ["Reduces cravings", "Boosts mood and energy"],
     cons: ["Requires time and consistency"],
@@ -82,11 +89,12 @@ export const methods = [
     access: "No prescription needed. Use local Michigan trails or parks.",
     sample: "N/A",
     goodrx: "",
-    image: "path/to/exercise.jpg"
+    image: "https://source.unsplash.com/featured/?exercise"
   },
   {
     name: "Deep Breathing",
     type: "Behavioral Strategy",
+    description: "Simple relaxation technique to calm urges.",
     cost: "Free",
     pros: ["Calms nerves", "Accessible anytime"],
     cons: ["Requires practice to be effective"],
@@ -94,11 +102,12 @@ export const methods = [
     access: "Practice anywhere. Helpful for Michigan winters when indoor relaxation is needed.",
     sample: "N/A",
     goodrx: "",
-    image: "path/to/breathing.jpg"
+    image: "https://source.unsplash.com/featured/?breathing"
   },
   {
     name: "Listening to Music",
     type: "Behavioral Strategy",
+    description: "Using favorite tunes as a positive distraction.",
     cost: "Free or subscription",
     pros: ["Distraction from cravings", "Mood booster"],
     cons: ["Requires access to music source"],
@@ -106,11 +115,12 @@ export const methods = [
     access: "Use streaming apps or Michigan libraries offering free music downloads.",
     sample: "N/A",
     goodrx: "",
-    image: "path/to/music.jpg"
+    image: "https://source.unsplash.com/featured/?music"
   },
   {
     name: "Chewing Raw Carrots or Sunflower Seeds",
     type: "Behavioral Strategy",
+    description: "Keeps the mouth busy with a healthy alternative.",
     cost: "$1–$5/week",
     pros: ["Keeps hands and mouth busy", "Healthy alternative"],
     cons: ["May increase snacking"],
@@ -118,11 +128,12 @@ export const methods = [
     access: "Available at Michigan grocery stores and food pantries.",
     sample: "N/A",
     goodrx: "",
-    image: "path/to/carrots.jpg"
+    image: "https://source.unsplash.com/featured/?carrots"
   },
   {
     name: "Support Groups",
     type: "Behavioral Strategy",
+    description: "Group meetings that offer peer encouragement.",
     cost: "Free or insurance covered",
     pros: ["Peer encouragement", "Structured support"],
     cons: ["May be hard to attend regularly"],
@@ -130,7 +141,7 @@ export const methods = [
     access: "Find local programs via Michigan Tobacco Quitline (1-800-QUIT-NOW) or MDHHS.",
     sample: "N/A",
     goodrx: "",
-    image: "path/to/group.jpg"
+    image: "https://source.unsplash.com/featured/?support-group"
   }
 ];
 


### PR DESCRIPTION
## Summary
- show tobacco cessation methods as modern cards
- allow expanding cards to reveal more details
- include short descriptions and sample images for each method
- add simple CSS styles

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643e2145148328b3e105386948e4fa