### PR TITLE
Upgrade jsPDF and Vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "heal-better-tobacco-vite",
       "version": "0.0.1",
       "dependencies": {
-        "jspdf": "^2.5.1",
+        "jspdf": "^3.0.1",
         "jspdf-autotable": "^3.5.28",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@vitejs/plugin-react": "^4.0.0",
+        "@vitejs/plugin-react": "^7.0.0",
         "gh-pages": "^6.3.0",
-        "vite": "^5.0.0"
+        "vite": "^7.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
-    "jspdf": "^2.5.1",
+    "jspdf": "^3.0.1",
     "jspdf-autotable": "^3.5.28",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.0.0",
+    "@vitejs/plugin-react": "^7.0.0",
     "gh-pages": "^6.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.0.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import methods from "./methods"; // tobacco cessation methods are in methods.js
 import { useState } from "react";
-import jsPDF from "jspdf";
+import { jsPDF } from "jspdf";
 import "jspdf-autotable";
 import "./App.css";
 


### PR DESCRIPTION
## Summary
- upgrade jsPDF to v3 and adjust import
- upgrade Vite to v7 and bump plugin version

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*
- `npm audit` *(fails: audit endpoint returned an error)*


------
https://chatgpt.com/codex/tasks/task_e_68656891d53883288c7c5bc0ad59e238