### PR TITLE
Improve layout colors and add page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Heal Better Tobacco Cessation</title>
+    <title>Tobacco Cessation Support Strategies</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -2,19 +2,39 @@
   padding: 1rem;
   font-family: sans-serif;
 }
+
+body {
+  background: #d9eef3;
+  color: #222;
+}
+
+:root {
+  --color-primary: #399396;
+  --color-secondary: #F26B42;
+  --color-accent: #ABCE3E;
+  --color-highlight: #01B4BC;
+}
 .welcome {
   margin-bottom: 1rem;
+  color: var(--color-primary);
 }
 .controls {
   margin-bottom: 1rem;
+  color: var(--color-secondary);
+}
+
+.title {
+  text-align: center;
+  margin-bottom: 1rem;
+  color: var(--color-primary);
 }
 .grid {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
 }
 .card {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-primary);
   border-radius: 6px;
   overflow: hidden;
   cursor: pointer;
@@ -25,7 +45,7 @@
 }
 .card img {
   width: 100%;
-  height: 160px;
+  aspect-ratio: 1/1;
   object-fit: cover;
 }
 .card-content {
@@ -33,19 +53,27 @@
   text-align: center;
 }
 .card-details {
-  background: #f5f5f5;
+  background: var(--color-highlight);
   padding: 0.5rem;
   font-size: 0.9rem;
+  color: #fff;
 }
 .favorite {
-  border-color: #22c55e;
+  border-color: var(--color-accent);
 }
 .btn {
   margin-top: 0.5rem;
   padding: 0.25rem 0.5rem;
   border: none;
-  background: #3182ce;
+  background: var(--color-secondary);
   color: #fff;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.footer {
+  margin-top: 2rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--color-secondary);
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,7 +51,9 @@ export default function HealBetterTobaccoCessationOptions() {
   };
 
   return (
+    <>
     <div className="container">
+      <h1 className="title">Tobacco Cessation Support Strategies</h1>
       <p className="welcome">
         Explore resources to help you quit! Click on any of the options to learn more about it. Save your favorites and print them as a reminder.
       </p>
@@ -116,5 +118,9 @@ export default function HealBetterTobaccoCessationOptions() {
         )}
       </div>
     </div>
+    <footer className="footer">
+      Made by <a href="https://www.hbomich.org/" target="_blank" rel="noopener noreferrer">HBOM</a>. Last updated {new Date(document.lastModified).toLocaleDateString("en-US")}
+    </footer>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- switch page title to "Tobacco Cessation Support Strategies"
- add global background color and high-contrast text
- insert a page header and footer with last updated date

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b8615a688328bbe9791a91f96b25