### PR TITLE
Improve homepage style

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,16 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tobacco Cessation Support Strategies</title>
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap"
+        rel="stylesheet"
+      />
+      <title>Tobacco Cessation Support Strategies</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -1,12 +1,20 @@
-.container {
-  padding: 1rem;
-  font-family: sans-serif;
+
+body {
+  background: #00b3bc;
+  color: #000;
+  font-family: 'Open Sans', sans-serif;
 }
 
-.body {
-  background: #d9eef3;
-  color: #222;
+* {
+  box-sizing: border-box;
 }
+
+.container {
+  padding: 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
 
 :root {
   --color-primary: #399396;
@@ -31,17 +39,19 @@
 .grid {
   display: grid;
   gap: 2rem;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }
 .card {
+  background: #fff;
   border: 1px solid var(--color-primary);
-  border-radius: 6px;
+  border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
-  transition: box-shadow 0.2s;
+  transition: box-shadow 0.2s, transform 0.2s;
 }
 .card:hover {
-  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+  transform: translateY(-2px);
 }
 .card img {
   width: 100%;
@@ -56,7 +66,7 @@
   background: var(--color-highlight);
   padding: 0.5rem;
   font-size: 0.9rem;
-  color: #fff;
+  color: #000;
 }
 .favorite {
   border-color: var(--color-accent);


### PR DESCRIPTION
## Summary
- import Open Sans font and apply to app
- change background to teal and text to black
- polish layout and card styles with modern look

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebc275c3c8328b05a37c6270d18a2