### PR TITLE
Add Quitlink button for MDHHS samples

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -81,6 +81,17 @@ body {
   cursor: pointer;
 }
 
+.btn-quitlink {
+  background: #006c79;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.btn-quitlink img {
+  height: 20px;
+}
+
 .footer {
   margin-top: 2rem;
   text-align: center;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,6 +117,21 @@ export default function HealBetterTobaccoCessationOptions() {
                 ) : (
                   <p><strong>GoodRx Estimate:</strong> {method.cost}</p>
                 )}
+                {method.sample && method.sample.toLowerCase() === "yes" && (
+                  <a
+                    className="btn btn-quitlink"
+                    href="https://michigan.quitlogix.org/en-us/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <img
+                      src="https://michigan.quitlogix.org/Libraries/media/ClientLogo/TobaccoQuitLink_Logo-Reverse.png?ext=.png"
+                      alt="Tobacco Quitlink logo"
+                    />
+                    Get Free Sample From the Quitlink
+                  </a>
+                )}
                 <button className="btn" onClick={(e) => { e.stopPropagation(); toggleFavorite(method.name); }}>
                   {favorites.includes(method.name) ? 'Remove from Favorites' : 'Add to Favorites'}
                 </button>


### PR DESCRIPTION
## Summary
- show a Get Free Sample From the Quitlink button when a method's sample is available from MDHHS
- style the new button in teal and display the Quitlink logo

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed079d7f0832887e37e321b20914d