### PR TITLE
Update Quitlink button style and text

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -91,7 +91,8 @@ body {
 }
 
 .btn-quitlink img {
-  height: 20px;
+  height: 1em;
+  width: auto;
 }
 
 .footer {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -125,11 +125,11 @@ export default function HealBetterTobaccoCessationOptions() {
                     rel="noopener noreferrer"
                     onClick={(e) => e.stopPropagation()}
                   >
+                    Get from
                     <img
                       src="https://michigan.quitlogix.org/Libraries/media/ClientLogo/TobaccoQuitLink_Logo-Reverse.png?ext=.png"
-                      alt="Tobacco Quitlink logo"
+                      alt="Michigan Tobacco Quitlink"
                     />
-                    Get Free Sample From the Quitlink
                   </a>
                 )}
                 <button className="btn" onClick={(e) => { e.stopPropagation(); toggleFavorite(method.name); }}>


### PR DESCRIPTION
## Summary
- tweak CSS for Quitlink button logo to scale with button size
- update Quitlink button text and alt text

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed639a6a4832898d9d7616b452856