### PR TITLE
Add quitlink filters and tags

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -29,6 +29,19 @@ body {
 .controls {
   margin-bottom: 1rem;
   color: #fff;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.btn.active {
+  background: var(--color-accent);
 }
 
 .title {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ export default function HealBetterTobaccoCessationOptions() {
   const [favorites, setFavorites] = useState([]);
   const [expanded, setExpanded] = useState(null);
   const [showFreeSamplesOnly, setShowFreeSamplesOnly] = useState(false);
+  const [filter, setFilter] = useState("All");
 
   const toggleFavorite = (methodName) => {
     setFavorites(prev =>
@@ -26,9 +27,13 @@ export default function HealBetterTobaccoCessationOptions() {
     );
   };
 
-  const filteredMethods = showFreeSamplesOnly
-    ? methods.filter(m => m.sample?.toLowerCase() === "yes")
-    : methods;
+  const filteredMethods = methods.filter(m => {
+    if (showFreeSamplesOnly && m.sample?.toLowerCase() !== "yes") {
+      return false;
+    }
+    if (filter === "All") return true;
+    return m.tags?.includes(filter);
+  });
 
   const handleExportPDF = () => {
     const doc = new jsPDF();
@@ -47,7 +52,7 @@ export default function HealBetterTobaccoCessationOptions() {
     });
 
     doc.autoTable({
-      head: [["Name", "Type", "Cost", "Free Sample (MDHHS)", "GoodRx URL"]],
+      head: [["Name", "Type", "Cost", "Free Sample (Quitlink)", "GoodRx URL"]],
       body: tableData,
       startY: 30,
       styles: { fontSize: 10, cellWidth: 'wrap' },
@@ -67,14 +72,23 @@ export default function HealBetterTobaccoCessationOptions() {
         Explore resources to help you quit! Click on any of the options to learn more about it. Save your favorites and print them as a reminder.
       </p>
       <div className="controls">
-        <label>
-          <input
-            type="checkbox"
-            checked={showFreeSamplesOnly}
-            onChange={() => setShowFreeSamplesOnly(!showFreeSamplesOnly)}
-          />
-          <span>Show only methods with free samples from MDHHS</span>
-        </label>
+        <button
+          className={`btn ${showFreeSamplesOnly ? 'active' : ''}`}
+          onClick={() => setShowFreeSamplesOnly(!showFreeSamplesOnly)}
+        >
+          Free Sample from the Quitlink
+        </button>
+        <div className="filter-group">
+          {['All', 'Nicotine Replacement', 'Prescription Medication', 'Other'].map(cat => (
+            <button
+              key={cat}
+              className={`btn ${filter === cat ? 'active' : ''}`}
+              onClick={() => setFilter(cat)}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
       </div>
 
       <div className="grid">
@@ -100,7 +114,7 @@ export default function HealBetterTobaccoCessationOptions() {
                 <p><strong>Cons:</strong> {method.cons?.join(", ")}</p>
                 <p><strong>How to Use:</strong> {method.usage}</p>
                 <p><strong>How to Get It:</strong> {method.access}</p>
-                <p><strong>Free Sample Available From MDHHS:</strong> {method.sample}</p>
+                <p><strong>Free Sample Available From Quitlink:</strong> {method.sample}</p>
                 {method.goodrx ? (
                   isValidUrl(method.goodrx) ? (
                     <p><strong>GoodRx Estimate:</strong>{" "}

--- a/src/methods.js
+++ b/src/methods.js
@@ -3,6 +3,7 @@ export const methods = [
   {
     name: "Varenicline (Chantix)",
     type: "Prescription Medication",
+    tags: ["Prescription Medication"],
     description: "Non-nicotine pill that eases cravings and withdrawal symptoms.",
     cost: "$100–$500/month",
     pros: ["Reduces cravings and withdrawal", "Non-nicotine option"],
@@ -16,6 +17,7 @@ export const methods = [
   {
     name: "Bupropion (Zyban)",
     type: "Prescription Medication",
+    tags: ["Prescription Medication"],
     description: "Antidepressant that can also reduce tobacco cravings.",
     cost: "$50–$150/month",
     pros: ["Reduces cravings", "May also help with depression"],
@@ -29,6 +31,7 @@ export const methods = [
   {
     name: "Nicotine Patch",
     type: "Nicotine Replacement Therapy (NRT)",
+    tags: ["Nicotine Replacement"],
     description: "Provides steady nicotine through the skin all day.",
     cost: "$25–$80/month (OTC)",
     pros: ["Simple to use", "Provides steady nicotine delivery"],
@@ -42,6 +45,7 @@ export const methods = [
   {
     name: "Nicotine Gum",
     type: "Nicotine Replacement Therapy (NRT)",
+    tags: ["Nicotine Replacement"],
     description: "Chewable form that helps manage sudden cravings.",
     cost: "$20–$50/month (OTC)",
     pros: ["Helps manage cravings", "Flexible use"],
@@ -55,6 +59,7 @@ export const methods = [
   {
     name: "Nicotine Lozenge",
     type: "Nicotine Replacement Therapy (NRT)",
+    tags: ["Nicotine Replacement"],
     description: "Dissolves in the mouth to curb oral cravings.",
     cost: "$25–$60/month (OTC)",
     pros: ["Easy to use", "Good for oral cravings"],
@@ -68,6 +73,7 @@ export const methods = [
   {
     name: "Nicotine Nasal Spray",
     type: "Nicotine Replacement Therapy (Prescription)",
+    tags: ["Nicotine Replacement", "Prescription Medication"],
     description: "Rapid‑acting spray for intense cravings.",
     cost: "$50–$150/month",
     pros: ["Fast relief", "Helpful for strong cravings"],
@@ -81,6 +87,7 @@ export const methods = [
   {
     name: "Exercise",
     type: "Behavioral Strategy",
+    tags: ["Other"],
     description: "Physical activity to distract and improve mood.",
     cost: "Free",
     pros: ["Reduces cravings", "Boosts mood and energy"],
@@ -94,6 +101,7 @@ export const methods = [
   {
     name: "Deep Breathing",
     type: "Behavioral Strategy",
+    tags: ["Other"],
     description: "Simple relaxation technique to calm urges.",
     cost: "Free",
     pros: ["Calms nerves", "Accessible anytime"],
@@ -107,6 +115,7 @@ export const methods = [
   {
     name: "Listening to Music",
     type: "Behavioral Strategy",
+    tags: ["Other"],
     description: "Using favorite tunes as a positive distraction.",
     cost: "Free or subscription",
     pros: ["Distraction from cravings", "Mood booster"],
@@ -120,6 +129,7 @@ export const methods = [
   {
     name: "Chewing Raw Carrots or Sunflower Seeds",
     type: "Behavioral Strategy",
+    tags: ["Other"],
     description: "Keeps the mouth busy with a healthy alternative.",
     cost: "$1–$5/week",
     pros: ["Keeps hands and mouth busy", "Healthy alternative"],
@@ -134,6 +144,7 @@ export const methods = [
   {
     name: "Support Groups",
     type: "Behavioral Strategy",
+    tags: ["Other"],
     description: "Group meetings that offer peer encouragement.",
     cost: "Free or insurance covered",
     pros: ["Peer encouragement", "Structured support"],


### PR DESCRIPTION
## Summary
- add tags for filter categories in `methods.js`
- change free sample label to reference the Quitlink
- add filter buttons in the UI and update PDF heading
- tweak styles for filter controls

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eda4733a08328be789e39f648ebfa