### PR TITLE
Update styles for lighter theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,7 @@
 
 body {
-  background: #00b3bc;
-  color: #fff;
+  background: #fdfdfd;
+  color: #333;
   font-family: 'Open Sans', sans-serif;
 }
 
@@ -24,11 +24,11 @@ body {
 }
 .welcome {
   margin-bottom: 1rem;
-  color: #fff;
+  color: #333;
 }
 .controls {
   margin-bottom: 1rem;
-  color: #fff;
+  color: #333;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -47,7 +47,7 @@ body {
 .title {
   text-align: center;
   margin-bottom: 1rem;
-  color: #fff;
+  color: #333;
 }
 .grid {
   display: grid;
@@ -58,9 +58,11 @@ body {
 .card {
   background: #fff;
   color: #000;
-  border: 1px solid var(--color-primary);
-  border-radius: 8px;
-  overflow: hidden;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  padding: 10px;
+  text-align: center;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.05);
   cursor: pointer;
   transition: box-shadow 0.2s, transform 0.2s;
 }
@@ -88,13 +90,17 @@ body {
   border-color: var(--color-accent);
 }
 .btn {
-  margin-top: 0.5rem;
-  padding: 0.25rem 0.5rem;
-  border: none;
-  background: var(--color-secondary);
-  color: #fff;
-  border-radius: 4px;
+  margin: 4px;
+  padding: 8px 16px;
+  border: 1px solid #ccc;
+  background-color: #f0f0f0;
+  color: #333;
+  border-radius: 6px;
+  font-size: 14px;
   cursor: pointer;
+}
+.btn:hover {
+  background-color: #e6f5eb;
 }
 
 
@@ -102,5 +108,5 @@ body {
   margin-top: 2rem;
   text-align: center;
   font-size: 0.9rem;
-  color: #fff;
+  color: #333;
 }


### PR DESCRIPTION
## Summary
- switch home page background to light gray
- restyle buttons with softer shades
- match card layout to quit-method tool
- update text colors for readability

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686edf2906f88328bede64a79c7f7ecc