### PR TITLE
Add iframe height messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Heal Better Tobacco Cessation Widget
+
+This project provides an embeddable React application that lists tobacco cessation strategies. The app can be embedded in other websites via an `<iframe>`.
+
+## Embedding
+
+Use the following HTML to embed the app:
+
+```html
+<iframe
+  src="https://noa-kim.github.io/heal-better-tobacco-vite/"
+  style="width:100%;border:0;overflow:hidden" 
+  scrolling="no"></iframe>
+```
+
+Because the widget may be served from a different origin than the host page, make sure the host page is able to receive cross‑origin messages.
+
+## Automatic Height Adjustment
+
+The app sends its height to the parent window whenever it loads or the window resizes. The parent page can adjust the iframe height by listening for the `hb-height` message.
+
+### WordPress Example
+
+Add the following snippet to your WordPress theme or via a custom HTML block to automatically resize the iframe:
+
+```html
+<script>
+window.addEventListener('message', function(e) {
+  if (e.data && e.data.type === 'hb-height') {
+    const frame = document.querySelector('iframe[src*="heal-better-tobacco-vite"]');
+    if (frame) {
+      frame.style.height = e.data.height + 'px';
+    }
+  }
+});
+</script>
+```
+
+This listens for the `hb-height` message and sets the matching iframe's height accordingly.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import methods from "./methods"; // tobacco cessation methods are in methods.js
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { getIframeHeight } from "./iframeHeight";
 import { jsPDF } from "jspdf";
 import "jspdf-autotable";
 import "./App.css";
@@ -63,6 +64,17 @@ export default function HealBetterTobaccoCessationOptions() {
 
     doc.save("tobacco_cessation_favorites.pdf");
   };
+
+  useEffect(() => {
+    const sendHeight = () => {
+      const height = getIframeHeight();
+      window.parent.postMessage({ type: 'hb-height', height }, '*');
+    };
+
+    sendHeight();
+    window.addEventListener('resize', sendHeight);
+    return () => window.removeEventListener('resize', sendHeight);
+  }, []);
 
   return (
     <>

--- a/src/iframeHeight.js
+++ b/src/iframeHeight.js
@@ -1,0 +1,3 @@
+export const getIframeHeight = () => {
+  return document.documentElement.scrollHeight;
+};


### PR DESCRIPTION
## Summary
- add helper to measure the scroll height
- notify parent window of iframe height on mount and resize
- explain how to embed the widget in README
- document a WordPress snippet for height adjustment

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee4943c548328953d28928cef5ce2