### PR TITLE
Improve card spacing and layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -52,15 +52,15 @@ body {
 .grid {
   display: grid;
   gap: 2.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(min(100%, 250px), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   justify-content: center;
-};
+}
 .card {
   background: #fff;
   color: #000;
   border: 1px solid #ddd;
-  border-radius: 10px;
-  padding: 10px;
+  border-radius: 15px;
+  padding: 1rem;
   text-align: center;
   box-shadow: 0 2px 5px rgba(0,0,0,0.05);
   cursor: pointer;
@@ -76,15 +76,16 @@ body {
   object-fit: cover;
 }
 .card-content {
-  padding: 0.5rem;
+  padding: 1rem;
   text-align: center;
   color: #000;
 }
 .card-details {
   background: #CCF0F2;
-  padding: 0.5rem;
+  padding: 1rem;
   font-size: 0.9rem;
   color: #000;
+  border-radius: 0 0 15px 15px;
 }
 .favorite {
   border-color: var(--color-accent);


### PR DESCRIPTION
## Summary
- update grid to auto-fit 4 cards per row when space allows
- increase card border radius and padding
- bump internal padding on card content and details

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee98441808328b9aff8bdfd33d4be