### PR TITLE
Add heart icon for favorites

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -104,6 +104,23 @@ body {
   background-color: #e6f5eb;
 }
 
+.favorite-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.heart-icon {
+  width: 16px;
+  height: 16px;
+  fill: #999;
+  transition: fill 0.2s;
+}
+
+.favorite-btn.active .heart-icon {
+  fill: #db5e47;
+}
+
 
 .footer {
   margin-top: 2rem;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -159,7 +159,20 @@ export default function HealBetterTobaccoCessationOptions() {
                 ) : (
                   <p><strong>GoodRx Estimate:</strong> {method.cost}</p>
                 )}
-                <button className="btn" onClick={(e) => { e.stopPropagation(); toggleFavorite(method.name); }}>
+                <button
+                  className={`btn favorite-btn ${favorites.includes(method.name) ? 'active' : ''}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleFavorite(method.name);
+                  }}
+                >
+                  <svg
+                    className="heart-icon"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+                  </svg>
                   {favorites.includes(method.name) ? 'Remove from Favorites' : 'Add to Favorites'}
                 </button>
               </div>


### PR DESCRIPTION
## Summary
- show a heart icon on the "Add to Favorites" button
- color the heart #db5e47 when a method is favorited

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ff1da54b08328bf0b1137b9386031