### PR TITLE
Make card images smaller

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -92,9 +92,11 @@ body {
   transform: translateY(-2px);
 }
 .card img {
-  width: 100%;
+  width: 70%;
   aspect-ratio: 1/1;
   object-fit: cover;
+  display: block;
+  margin: 0 auto;
 }
 .card-content {
   padding: 1rem;


### PR DESCRIPTION
## Summary
- resize images in tobacco method cards to 70% width for a smaller look

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717cc045bc8328acf900cc01dee744